### PR TITLE
PR to Dev

### DIFF
--- a/lib/btclient.js
+++ b/lib/btclient.js
@@ -12,40 +12,37 @@ var BTClient = function(options) {
 
     this.timeout = options.timeout;
     this.reqs = [];
-    this.filter = options.filter;
+    this.filter = options.filter ? options.filter : function(infohash, rinfo, callback) { callback(true); };
     this.maxConnections = options.maxConnections || 200;
+    this.activeConnections = 0;
+    this.maxItemsInQueue = options.maxItemsInQueue || (this.maxConnections * 10);
+    this.requestInterval = options.requestInterval || 200;
     this.on('download', this._download);
 
-    for (var i = 0; i < this.maxConnections; i++) {
-        this._next();
-    }
+    this._next();
 };
 
 util.inherits(BTClient, EventEmitter);
 
 BTClient.prototype._next = function() {
-    if (this.reqs.length > 0) {
+    if (this.activeConnections < this.maxConnections) {
         var req = this.reqs.shift();
-        if (typeof this.filter === 'function') {
+        if (req) {
             this.filter(req.infohash.toString('hex'), req.rinfo, function(drop) {
                 if (!drop) {
                     this.emit('download', req.rinfo, req.infohash);
                 }
             }.bind(this));
         }
-        else {
-            this.emit('download', req.rinfo, req.infohash);
-        }
     }
-    else {
-        setTimeout(function() {
-            this._next();
-        }.bind(this), 1000);
-    }
+    setTimeout(function() {
+        this._next();
+    }.bind(this), this.requestInterval);
 };
 
 BTClient.prototype._download = function(rinfo, infohash) {
     var socket = new net.Socket();
+    this.activeConnections++;
     socket.setTimeout(this.timeout || 5000);
     socket.connect(rinfo.port, rinfo.address, function() {
         var wire = new Wire(infohash);
@@ -73,12 +70,12 @@ BTClient.prototype._download = function(rinfo, infohash) {
 
     socket.once('close', function() {
         socket.destroy();
-        this._next();
+        this.activeConnections--;
     }.bind(this));
 };
 
 BTClient.prototype.push = function(rinfo, infohash) {
-    if (this.reqs.length >= this.maxConnections) {
+    if (this.reqs.length >= this.maxItemsInQueue) {
         return;
     }
     this.reqs.push({ infohash: infohash, rinfo: rinfo });

--- a/lib/fetch_queue.js
+++ b/lib/fetch_queue.js
@@ -3,6 +3,7 @@
 var utils = require('./utils');
 
 var FetchQeueue = function(timeout, fetchDataFunc) {
+    var interval = timeout / 10;
     var queues = this.queues = {};
     setInterval(function() {
     	var now = new Date().getTime();
@@ -10,27 +11,24 @@ var FetchQeueue = function(timeout, fetchDataFunc) {
     		var item = queues[k];
     		// check timeout
     		if(item.lastTriedAt === 0 || now - item.lastTriedAt > timeout) {
-    			if(item.queues.length === 0) {
-    				// timeout and no items in queue, remove item
+    			if(item.queue.length === 0) {
+    				// timeout and no item in queue, remove queue
     				delete queues[k];
     			} else {
     				// timeout and try to fetch from next host
     				item.lastTriedAt = now;
-    				var meta = item.queues.shift();
+    				var meta = item.queue.shift();
     				fetchDataFunc(meta);
     			}
     		}
     	}
-    }, 200);
+    }, interval);
 };
 
 FetchQeueue.prototype.push = function(meta) {
 	var hash = meta.infohash;
 	if(!this.queues[hash]) {
-		this.queues[hash] = {
-			'lastTriedAt': 0,
-			'queue': []
-		};
+		this.queues[hash] = { 'lastTriedAt': 0, 'queue': [] };
 	} else {
 		this.queues[hash].queue.push(meta);
 	}

--- a/lib/fetch_queue.js
+++ b/lib/fetch_queue.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var utils = require('./utils');
+
+var FetchQeueue = function(timeout, fetchDataFunc) {
+    this.queues = {};
+    setInterval(function() {
+    	var now = new Date().getTime();
+    	for(var k in this.queues) {
+    		var item = this.queues[k];
+    		// check timeout
+    		if(item.lastTriedAt === 0 || now - item.lastTriedAt > timeout) {
+    			if(item.queues.length === 0) {
+    				// timeout and no items in queue, remove item
+    				delete this.queues[k];
+    			} else {
+    				// timeout and try to fetch from next host
+    				item.lastTriedAt = now;
+    				var meta = item.queues.shift();
+    				fetchDataFunc(meta);
+    			}
+    		}
+    	}
+    }, 200);
+};
+
+FetchQeueue.prototype.push = function(meta) {
+	var hash = meta.infohash;
+	if(!this.queues[hash]) {
+		this.queues[hash] = {
+			'lastTriedAt': 0,
+			'queue': []
+		};
+	} else {
+		this.queues[hash].queue.push(meta);
+	}
+}
+
+FetchQeueue.prototype.remove = function(hash) {
+	delete this.queues[hash];
+}
+
+module.exports = FetchQeueue;

--- a/lib/fetch_queue.js
+++ b/lib/fetch_queue.js
@@ -3,16 +3,16 @@
 var utils = require('./utils');
 
 var FetchQeueue = function(timeout, fetchDataFunc) {
-    this.queues = {};
+    var queues = this.queues = {};
     setInterval(function() {
     	var now = new Date().getTime();
-    	for(var k in this.queues) {
-    		var item = this.queues[k];
+    	for(var k in queues) {
+    		var item = queues[k];
     		// check timeout
     		if(item.lastTriedAt === 0 || now - item.lastTriedAt > timeout) {
     			if(item.queues.length === 0) {
     				// timeout and no items in queue, remove item
-    				delete this.queues[k];
+    				delete queues[k];
     			} else {
     				// timeout and try to fetch from next host
     				item.lastTriedAt = now;

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,9 @@ P2PSpider.prototype.listen = function (port, address) {
     var btclient = new BTClient({
         timeout: this.options.timeout || 1000 * 10,
         filter: this.filter,
-        maxConnections: this.options.maxConnections
+        maxConnections: this.options.maxConnections,
+        maxItemsInQueue: this.options.maxItemsInQueue,
+        requestInterval: this.options.requestInterval
     });
 
     btclient.on('complete', function(metadata, infohash, rinfo) {

--- a/samples/elasticsearch.js
+++ b/samples/elasticsearch.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var P2PSpider = require('./lib');
+var elasticsearch = require('elasticsearch');
+
+var client = new elasticsearch.Client({'host': 'localhost:9200'});
+
+var p2p = P2PSpider({
+    nodesMaxSize: 200,
+    maxConnections: 400,
+    timeout: 5000
+});
+
+p2p.ignore(function (infohash, rinfo, callback) {
+    client.exists({ index: 'bt', type: 'json', id: infohash }, function (error, exists) { console.log(infohash + " : " + exists); callback(exists); });
+});
+
+p2p.on('metadata', function (metadata) {
+    var data = {};
+    data.magnet = metadata.magnet;
+    data.name = metadata.info.name ? metadata.info.name.toString() : '';
+    data.fetchedAt = new Date().getTime();
+    client.create({ index: 'bt', type: 'json', id: metadata.infohash, body: data }, function (error, resp) {  });
+    console.log(data.name);
+});
+
+p2p.listen(6881, '0.0.0.0');

--- a/samples/elasticsearch.js
+++ b/samples/elasticsearch.js
@@ -3,8 +3,9 @@
 /**
  * Sample of using elastic search to store and index fetched p2p data.
  * Usage:
- *  1. npm install elasticsearch --save
+ *  1. npm install elasticsearch
  *  2. docker run --name elasticsearch -d -p 9200:9200 -p 9300:9300 elasticsearch
+ *  3. node samples/elasticsearch.js
  *
  * The ElasticUI can be used as a simple frontend UI.
  */
@@ -12,7 +13,7 @@
 var P2PSpider = require('../lib');
 var elasticsearch = require('elasticsearch');
 
-var client = new elasticsearch.Client({'host': 'localhost:9200'});
+var client = new elasticsearch.Client({host: 'localhost:9200'});
 
 var p2p = P2PSpider({
     nodesMaxSize: 200,
@@ -21,7 +22,9 @@ var p2p = P2PSpider({
 });
 
 p2p.ignore(function (infohash, rinfo, callback) {
-    client.exists({ index: 'bt', type: 'json', id: infohash }, function (error, exists) { console.log(infohash + " : " + exists); callback(exists); });
+    client.exists({ index: 'bt', type: 'meta', id: infohash }, function (error, exists) {
+        callback(exists);
+    });
 });
 
 p2p.on('metadata', function (metadata) {
@@ -29,8 +32,11 @@ p2p.on('metadata', function (metadata) {
     data.magnet = metadata.magnet;
     data.name = metadata.info.name ? metadata.info.name.toString() : '';
     data.fetchedAt = new Date().getTime();
-    client.create({ index: 'bt', type: 'json', id: metadata.infohash, body: data }, function (error, resp) {  });
-    console.log(data.name);
+    client.index({ index: 'bt', type: 'meta', id: metadata.infohash, body: data }, function (error, resp) {
+        if(!error) {
+            console.log(data.name);
+        }
+    });
 });
 
 p2p.listen(6881, '0.0.0.0');

--- a/samples/elasticsearch.js
+++ b/samples/elasticsearch.js
@@ -1,6 +1,15 @@
 'use strict';
 
-var P2PSpider = require('./lib');
+/**
+ * Sample of using elastic search to store and index fetched p2p data.
+ * Usage:
+ *  1. npm install elasticsearch --save
+ *  2. docker run --name elasticsearch -d -p 9200:9200 -p 9300:9300 elasticsearch
+ *
+ * The ElasticUI can be used as a simple frontend UI.
+ */
+
+var P2PSpider = require('../lib');
 var elasticsearch = require('elasticsearch');
 
 var client = new elasticsearch.Client({'host': 'localhost:9200'});

--- a/samples/elasticsearch.js
+++ b/samples/elasticsearch.js
@@ -22,7 +22,7 @@ var p2p = P2PSpider({
 });
 
 p2p.ignore(function (infohash, rinfo, callback) {
-    client.exists({ index: 'bt', type: 'meta', id: infohash }, function (error, exists) {
+    client.exists({ index: 'seeds', type: 'meta', id: infohash }, function (error, exists) {
         callback(exists);
     });
 });
@@ -32,7 +32,7 @@ p2p.on('metadata', function (metadata) {
     data.magnet = metadata.magnet;
     data.name = metadata.info.name ? metadata.info.name.toString() : '';
     data.fetchedAt = new Date().getTime();
-    client.index({ index: 'bt', type: 'meta', id: metadata.infohash, body: data }, function (error, resp) {
+    client.index({ index: 'seeds', type: 'meta', id: metadata.infohash, body: data }, function (error, resp) {
         if(!error) {
             console.log(data.name);
         }

--- a/samples/elasticsearch.js
+++ b/samples/elasticsearch.js
@@ -34,13 +34,9 @@ p2p.on('metadata', function(metadata) {
     data.magnet = metadata.magnet;
     data.name = metadata.info.name ? metadata.info.name.toString() : '';
     data.fetchedAt = new Date().getTime();
-    client.exists({ index: 'seeds', type: 'meta', id: metadata.infohash }, function(error, exists) {
-        if (!exists) {
-            client.index({ index: 'seeds', type: 'meta', id: metadata.infohash, body: data }, function(error, resp) {
-                if (!error) {
-                    console.log(data.name);
-                }
-            });
+    client.index({ index: 'seeds', type: 'meta', id: metadata.infohash, body: data }, function(error, resp) {
+        if (!error) {
+            console.log(data.name);
         }
     });
 });

--- a/samples/leveldb.js
+++ b/samples/leveldb.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/**
+ * Sample of using leveldb to store fetched p2p data.
+ * Need to install leveld first:
+ *  1. npm install level
+ *  2. node samples/leveldb.js
+ */
+
+var P2PSpider = require('../lib');
+var level = require('level');
+
+var db = level('./leveldb')
+
+var p2p = P2PSpider({
+    nodesMaxSize: 200,
+    maxConnections: 400,
+    timeout: 5000
+});
+
+p2p.ignore(function (infohash, rinfo, callback) {
+    db.get('name', function (err, value) {
+        callback(!err);
+    });
+});
+
+p2p.on('metadata', function (metadata) {
+    var data = {};
+    data.magnet = metadata.magnet;
+    data.name = metadata.info.name ? metadata.info.name.toString() : '';
+    data.fetchedAt = new Date().getTime();
+    db.put(metadata.infohash, JSON.stringify(data), function (err) { 
+        if(!err) {
+            console.log(data.name);
+        }
+    });
+});
+
+process.on('SIGINT', function() {
+    db.close(function(err) {
+        console.log("DB closed!");
+        process.exit();
+    });
+});
+
+p2p.listen(6881, '0.0.0.0');

--- a/samples/leveldb.js
+++ b/samples/leveldb.js
@@ -19,7 +19,7 @@ var p2p = P2PSpider({
 });
 
 p2p.ignore(function (infohash, rinfo, callback) {
-    db.get('name', function (err, value) {
+    db.get(infohash, function (err, value) {
         callback(!!err);
     });
 });

--- a/samples/leveldb.js
+++ b/samples/leveldb.js
@@ -10,7 +10,7 @@
 var P2PSpider = require('../lib');
 var level = require('level');
 
-var db = level('./leveldb')
+var db = level('./leveldb');
 
 var p2p = P2PSpider({
     nodesMaxSize: 200,
@@ -20,7 +20,7 @@ var p2p = P2PSpider({
 
 p2p.ignore(function (infohash, rinfo, callback) {
     db.get('name', function (err, value) {
-        callback(!err);
+        callback(!!err);
     });
 });
 
@@ -29,7 +29,7 @@ p2p.on('metadata', function (metadata) {
     data.magnet = metadata.magnet;
     data.name = metadata.info.name ? metadata.info.name.toString() : '';
     data.fetchedAt = new Date().getTime();
-    db.put(metadata.infohash, JSON.stringify(data), function (err) { 
+    db.put(metadata.infohash, JSON.stringify(data), function (err) {
         if(!err) {
             console.log(data.name);
         }


### PR DESCRIPTION
* 添加了两个sample，一个使用elastic search, 一个使用leveldb。见samples。

* 修改btclient.js。之前的版本会在短时间发起大量的请求，可能造成程序死掉。使用elastic search的时候，基本上在开始2～3分钟后就会发生。解决方法是，在每次请求之间等待一段时间。加入了对queue长度的限制。加入了对活动连接数的统计和限制。

* 添加了fetch_queue.js。详细请见我在 #19 中的留言。这个类没有测试，如果想法正确，还得麻烦您整合测试一下。